### PR TITLE
Feature/loop

### DIFF
--- a/EasyKey.git/git.sh
+++ b/EasyKey.git/git.sh
@@ -9,6 +9,7 @@ source "$script_dir/../shellmenu.sh"
 source "$script_dir/ezk-git-functions.sh"
 
 globalClmWidth=35
+immediateMode=true
 
 git fetch --all --tags 2> /dev/null
 

--- a/EasyKey.kubectl/kubectl.sh
+++ b/EasyKey.kubectl/kubectl.sh
@@ -9,6 +9,7 @@ source "$script_dir/../shellmenu.sh"
 source "$script_dir/ezk-kubectl-functions.sh"
 
 continuemenu=true
+immediateMode=true
 
 while ${continuemenu:=true}; do
 clear

--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ You can also look into [EasyKey.git](https://github.com/nschlimm/EasyKey.shellme
 Use `menuInit` to initialize a new menu.  
 Use `submenuHead` to structure your menu into sub sections.  
 Use `menuItem` to define keys in single column menus.  
-Use `menuItemClm` to define keys for multi column menus (allows more actions in the menu).  
+Use `menuItemClm` to define keys for multi column menus (allows more actions in the menu).
+Use `startMenu` to start your menu in your shell window.  
 
 ```
 menuInit <menu title>
 submenuHead <sub menu title>
 menuItem <key> <description> <shell command>
 menuItemClm <key> <description> <shell command> <key> <description> <shell command>
+startMenu
 ```
 
 # Maven demo menu
@@ -48,7 +50,6 @@ The following example are taken from `maven_example.sh` for illustration.
 
 ```
 source ./shellmenu.sh
-while ${continuemenu:=true}; do
 clear
 menuInit "Maven demo menu"
   submenuHead "Life cycle commands:"
@@ -63,9 +64,7 @@ menuInit "Maven demo menu"
     menuItem e "Show effective settings" "mvn help:effective-settings"
     menuItem r "Show local repo location" "mvn help:evaluate -Dexpression=settings.localRepository | grep -v '\[INFO\]'" 
     menuItem l "Show global settings file location" showGlobalSettingFile
-    echo && importantLog $(pwd)
-  choice
-done
+startMenu
 echo "bye, bye, homie!"
 ```
 Result is the following menu:

--- a/maven_example.sh
+++ b/maven_example.sh
@@ -37,6 +37,7 @@ menuInit "Maven demo menu"
     menuItem e "Show effective settings" "mvn help:effective-settings"
     menuItem r "Show local repo location" "mvn help:evaluate -Dexpression=settings.localRepository | grep -v '\[INFO\]'" 
     menuItem l "Show global settings file location" showGlobalSettingFile
+    generateMenu
   choice
 done
 echo "bye, bye, homie!"

--- a/maven_example.sh
+++ b/maven_example.sh
@@ -22,7 +22,8 @@ showGlobalSettingFile() {
   fi
 }
 
-while ${continuemenu:=true}; do
+immediateMode=false
+
 clear
 menuInit "Maven demo menu"
   submenuHead "Life cycle commands:"
@@ -37,7 +38,5 @@ menuInit "Maven demo menu"
     menuItem e "Show effective settings" "mvn help:effective-settings"
     menuItem r "Show local repo location" "mvn help:evaluate -Dexpression=settings.localRepository | grep -v '\[INFO\]'" 
     menuItem l "Show global settings file location" showGlobalSettingFile
-    generateMenu
-  choice
-done
+startMenu
 echo "bye, bye, homie!"

--- a/shellmenu.sh
+++ b/shellmenu.sh
@@ -5,9 +5,10 @@
 #################################
 
 # Globals
-waitonexit=true;
+waitonexit=true
 continuemenu=true
 globalClmWidth=45
+immediateMode=true
 
 ############################
 ############################
@@ -25,10 +26,14 @@ globalClmWidth=45
 menuInit () {
   actualmenu="$1"
   menudatamap=()
+  ${immediateMode} && printMenuHeading "$1"
+  echo
+}
+
+printMenuHeading(){
   export GREP_COLOR='1;37;44'
   echo "$1" | grep --color ".*"
   export GREP_COLOR='01;31'
-  echo
 }
 
 #################################################
@@ -40,6 +45,10 @@ menuInit () {
 #################################################
 submenuHead () { 
   actualsubmenuname="$1"
+  ${immediateMode} && printSubmenuHeading "$1"
+}
+
+printSubmenuHeading(){
   export GREP_COLOR='1;36'
   echo "$1" | grep --color ".*"
   export GREP_COLOR='01;31'
@@ -61,7 +70,11 @@ submenuHead () {
 #   Prints the menu item to standard out.
 #################################################
 menuItem () {
-   menudatamap+=("$1#$2#$3#$actualsubmenuname#$actualmenu")
+   menudatamap+=("$1#$2#$3#$actualsubmenuname#$actualmenu#1")
+   ${immediateMode} && printMenuItem "$1" "$2"
+}
+
+printMenuItem() {
    echo "$1. $2"
 }
 
@@ -87,14 +100,18 @@ menuItem () {
 #################################################
 menuItemClm () {
    clmLocalWidth=${globalClmWidth:=45}
-   menudatamap+=("$1#$2#$3#$actualsubmenuname#$actualmenu")
-   menudatamap+=("$4#$5#$6#$actualsubmenuname#$actualmenu")
-   echo -e "${1}.,${2},${4}.,${5}" \
-      | awk -F , -v OFS=, '{printf "%-3s",$1; 
-                            printf "%-'"${clmLocalWidth}"'s",$2; 
-                            printf "%-3s",$3; 
-                            printf "%-'"${clmLocalWidth}"'s",$4; 
-                            printf("\n"); }'
+   menudatamap+=("$1#$2#$3#$actualsubmenuname#$actualmenu#1")
+   menudatamap+=("$4#$5#$6#$actualsubmenuname#$actualmenu#2")
+   ${immediateMode} && printMenuItemClm "$1" "$2" "$4" "$5"
+}
+
+printMenuItemClm() {
+  echo -e "${1}.,${2},${3}.,${4}" \
+          | awk -F , -v OFS=, '{printf "%-3s",$1; 
+                                printf "%-'"${clmLocalWidth}"'s",$2; 
+                                printf "%-3s",$3; 
+                                printf "%-'"${clmLocalWidth}"'s",$4; 
+                                printf("\n"); }'
 }
 
 #####################################
@@ -353,6 +370,8 @@ waitonexit () {
 #################################################
 # Calls the function or shell command associated
 # to the key pressed by the user.
+# Arguments:
+#   $1: pressed key
 # Globals:
 #   menudatamap - the menu data
 # Outputs:
@@ -371,6 +390,16 @@ callKeyFunktion () {
          fi
    done
    return 5
+}
+
+generateMenu () { 
+  # Loop through the list
+  OLD_IFS=$IFS
+  for ((index=0; index<${#menudatamap[@]}; index++)); do
+    IFS="#" read -r key description action submenu menu column <<< "$menudata"
+
+  done
+  IFS="$OLD_IFS"
 }
 
 #################################################


### PR DESCRIPTION
Added the `startMenu` function to enable users to startMenu without writing there own loops.
Notice that there is a new `immediateMode` variable in the globals section. The standard value is `false` which enables the user to user `startMenu` function. If set to `true` users can write their own loops. See EasyKey.kubectl and EasyKey.git for custom loops.